### PR TITLE
README.md: explain MicroPython options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ pip install git+https://github.com/dogtopus/minipb
 
 **NOTE**: Despite being lightweight compared to official Protobuf, the `minipb` module itself still uses around 15KB of RAM after loaded via `import`. Therefore it is recommended to use MiniPB on MicroPython instances with minimum of 24KB of memory available to the scripts. Instances with at least 48KB of free memory is recommended for more complex program logic.
 
-First you need `mpy-cross` that is compatible with the mpy version you are using.
+On targets with plenty of RAM, such as Pyboards and the Unix build, installation consists of copying `minipb.py` to the filesystem and installing the `logging` module from [micropython-lib][mpylib]. For targets with restricted RAM there are two options: cross compilation and frozen bytecode. The latter offers the greatest saving. See the [official docs][mpydoc] for further explanation.
+
+Cross compilation may be achieved as follows. First you need `mpy-cross` that is compatible with the mpy version you are using.
 
 Compile MiniPB by using
 
@@ -91,3 +93,4 @@ Format string documentation can be found under the project [Wiki][wiki]. The mod
 [mpylib]: https://github.com/micropython/micropython-lib
 [wiki]: https://github.com/dogtopus/minipb/wiki
 [schema]: https://github.com/dogtopus/minipb/wiki/Schema-Representations
+[mpydoc]: http://docs.micropython.org/en/latest/reference/packages.html


### PR DESCRIPTION
Clarify the fact that installation options can vary depending on the platform in use. Frozen bytecode can be essential on some small devices. On the other hand this code runs fine on Pyboards with no need for cross-compilation.