### PR TITLE
Streaming decoder

### DIFF
--- a/minipb.py
+++ b/minipb.py
@@ -76,8 +76,7 @@ class BytesView:
         readlen = min(length, self.length)
         if readlen > 0:
             res = self.buf.read(readlen)
-            actual = len(res)
-            self.length -= actual
+            self.length -= len(res)
             return res
         else:
             return b""
@@ -942,18 +941,21 @@ class RawWire(Wire):
         return encoded.getvalue()
 
 
-def bisect_field_id(a, x, lo=0, hi=None):
-    if lo < 0:
-        raise ValueError('lo must be non-negative')
-    if hi is None:
-        hi = len(a)
+def bisect_field_id(a, x):
+    # without repeats this should work
+    mid = min(x-1, len(a)-1)
+    lo = 0
+    hi = len(a)
     while lo < hi:
+        res = a[mid]
+        fid = res['field_id']
+        if fid == x: return res
+        if fid < x: lo = mid+1
+        else: hi = mid
         mid = (lo+hi)//2
-        if a[mid]['field_id'] < x: lo = mid+1
-        elif a[mid]['field_id'] > x: hi = mid
-        else: return a[mid]
-    if a[lo]['field_id'] == x:
-        return a[lo]
+    res = a[lo]
+    if res['field_id'] == x:
+        return res
     else:
         return a[lo-1]
 

--- a/minipb.py
+++ b/minipb.py
@@ -80,7 +80,7 @@ class BytesView:
             self.length -= actual
             return res
         else:
-            return ""
+            return b""
 
 
 class Wire(object):

--- a/minipb.py
+++ b/minipb.py
@@ -67,15 +67,10 @@ else:
 
 class BytesView:
     def __init__(self, buf, length):
-        self.offset = buf.tell()
         self.buf = buf
         self.length = length
 
-    def tell(self):
-        return self.buf.tell()
-    
     def read(self, length=None):
-        assert self.buf.tell() == self.offset
         if not length:
             length = self.length
         readlen = min(length, self.length)
@@ -83,7 +78,6 @@ class BytesView:
             res = self.buf.read(readlen)
             actual = len(res)
             self.length -= actual
-            self.offset += actual
             return res
         else:
             return ""

--- a/minipb.py
+++ b/minipb.py
@@ -69,6 +69,20 @@ class BytesView:
         self.buf = buf
         self.length = length
 
+    def tell(self):
+        return self.buf.tell()
+
+    def readinto(self, buf):
+        # we don't do partial reads
+        # but it's only used with a length of 1
+        # so it's fine
+        remaining = self.length-(self.buf.tell()-self.offset)
+        if remaining >= len(buf):
+            read = self.buf.readinto(buf)
+            return read
+        else:
+            return 0
+
     def read(self, length=None):
         if not length:
             length = self.length
@@ -531,10 +545,11 @@ class Wire(object):
         """
         ctr = 0
         result = 0
+        tmp = bytearray(1)
         partial = False
         while 1:
-            tmp = buf.read(1)
-            if len(tmp) == 0:
+            count = buf.readinto(tmp)
+            if count == 0:
                 raise EndOfMessage(partial)
             else:
                 partial = True

--- a/minipb.py
+++ b/minipb.py
@@ -19,7 +19,6 @@ import logging
 import re
 import struct
 import io
-import bisect
 
 __all__ = [
     'BadFormatString', 'CodecError', 'EndOfMessage',

--- a/minipb.py
+++ b/minipb.py
@@ -76,9 +76,10 @@ class BytesView:
         # we don't do partial reads
         # but it's only used with a length of 1
         # so it's fine
-        remaining = self.length-(self.buf.tell()-self.offset)
+        remaining = self.length
         if remaining >= len(buf):
             read = self.buf.readinto(buf)
+            self.length -= read
             return read
         else:
             return 0

--- a/minipb.py
+++ b/minipb.py
@@ -957,6 +957,8 @@ def bisect_field_id(a, x, lo=0, hi=None):
     else:
         return a[lo-1]
 
+tk_start = "__start__"
+tk_end = "__end__"
 
 class IterWire(Wire):
     '''
@@ -978,13 +980,17 @@ class IterWire(Wire):
                 for f in unpacked_field:
                     res = self._decode_field(fmt['field_type'], f, fmt.get('subcontent'), mypath)
                     if hasattr(res, 'send'): # generator
+                        yield mypath, tk_start
                         yield from res
+                        yield mypath, tk_end
                     else:
                         yield mypath, res
             else:
                 res = self._decode_field(fmt['field_type'], field, fmt.get('subcontent'), mypath)
                 if hasattr(res, 'send'): # generator
+                    yield mypath, tk_start
                     yield from res
+                    yield mypath, tk_end
                 else:
                     yield mypath, res
 


### PR DESCRIPTION
As explained in #11 this PR adds a Wire class that decodes the data without allocating everything at once.

It's a bit hacky because it modifies some things to defer doing work until later which narrowly avoids interfering with normal Wire operation. Maybe there is a way to separate them cleaner or make Wire also more lazy, but I didn't want to break Wire too much.

One example could be to instead of keeping track of repeats, just repeat the value in the fmt dict, so that you can index into it directly rather than searching for the right value.

Probably needs some review, tests, and polish.
Here is some code I used for testing:
```python
import minipb
import gzip

value = (('string_value', 'U'),
         ('float_value', 'f'),
         ('double_value', 'd'),
         ('int_value', 't'),
         ('uint_value', 'T'),
         ('sint_value', 'z'))

feature = (('id', 'T'),
           ('tags', '#T'),
           ('type', 't'),
           ('geometry', '#T'))

layer = (('name', '*U'),
         ('features', '+[', feature, ']'),
         ('keys', '+U'),
         ('values', '+[', value, ']'),
         ('extent', 'T'),
         ('_', 'x9'),
         ('version', '*T'))

tile = (('_', 'x2'), ('layers', '+[', layer, ']'))

refwire = minipb.Wire(tile)

wire = minipb.IterWire(tile)

dec = gzip.open('[redaced]vtiles/10/522/330.pbf', 'rb').read()

print(refwire.decode(dec))

for p in wire.decode(dec):
    print(p)
```
Which outputs
```
{'layers': ({'name': 'water', 'features': ({'id': None, 'tags': (1, 0), 'type': 3, 'geometry': (9, 8320, 127, 26, 0, 8448, 8447, 0, 0, 8447, 15)},), 'keys': ('id', 'class', 'intermittent', 'brunnel'), 'values': ({'string_value': 'ocean', 'float_value': None, 'double_value': None, 'int_value': None, 'uint_value': None, 'sint_value': None},), 'extent': 4096, 'version': 2},)}
(('layers', 'name'), 'water')
(('layers', 'features', 'tags'), 1)
(('layers', 'features', 'tags'), 0)
(('layers', 'features', 'type'), 3)
(('layers', 'features', 'geometry'), 9)
(('layers', 'features', 'geometry'), 8320)
(('layers', 'features', 'geometry'), 127)
(('layers', 'features', 'geometry'), 26)
(('layers', 'features', 'geometry'), 0)
(('layers', 'features', 'geometry'), 8448)
(('layers', 'features', 'geometry'), 8447)
(('layers', 'features', 'geometry'), 0)
(('layers', 'features', 'geometry'), 0)
(('layers', 'features', 'geometry'), 8447)
(('layers', 'features', 'geometry'), 15)
(('layers', 'keys'), 'id')
(('layers', 'keys'), 'class')
(('layers', 'keys'), 'intermittent')
(('layers', 'keys'), 'brunnel')
(('layers', 'values', 'string_value'), 'ocean')
(('layers', 'extent'), 4096)
(('layers', 'version'), 2)
```

This is using a mapbox vector tile  sample:
[330.zip](https://github.com/dogtopus/minipb/files/9306807/330.zip)