### PR TITLE
Add Message and Fields, acting like mini ORM for encoding/decoding Me…

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ from minipb import TYPE_STRING, TYPE_INT32, process_message_fields, Message, Fie
 @process_message_fields
 class Person(Message):
     name   = Field(1, TYPE_STRING, required=True)
-    id     = Field(2, TYPE_INT32, required=True)
+    id     = Field(2, TYPE_INT, required=True)
     email  = Field(3, TYPE_STRING)
 
     @process_message_fields
     class PhoneNumber(Message):
         number = Field(1, TYPE_STRING, required=True)
-        type   = Field(2, TYPE_INT32)
+        type   = Field(2, TYPE_INT)
 
     phone  = Field(4, PhoneNumber, repeated=True)
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Mini Protobuf library in pure Python.
 ```python
 import minipb
 
-
+### Encode/Decode a message with the Wire object and Key-Value Schema
 # Create the Wire object with schema
 hello_world_msg = minipb.Wire([
     ('msg', 'U') # 'U' means UTF-8 string.
@@ -34,7 +34,7 @@ decoded_msg = hello_world_msg.decode(encoded_msg)
 # decoded_msg == {'msg': 'Hello world!'}
 
 
-# Alternatively, use the format string
+### Encode/Decode a message with the Wire object and Format String
 hello_world_msg = minipb.Wire('U')
 
 # Encode a message
@@ -44,6 +44,31 @@ encoded_msg = hello_world_msg.encode('Hello world!')
 # Decode a message
 decoded_msg = hello_world_msg.decode(encoded_msg)
 # decoded_msg == ('Hello world!',)
+
+
+### Encode/Decode a Message with schema defined via Fields
+@minipb.process_message_fields
+class HelloWorldMessage(minipb.Message):
+    msg = minipb.Field(1, minipb.TYPE_STRING)
+
+# Creating a Message instance
+#   Method 1: init with kwargs work!
+msg_obj = HelloWorldMessage(msg='Hello world!')
+
+#   Method 2: from_dict, iterates over all Field's declared in order on the class
+msg_obj = HelloWorldMessage.from_dict({'msg': 'Hello world!'})
+
+# Encode a message
+encoded_msg = msg_obj.encode()
+# encoded_message == b'\n\x0cHello world!'
+
+# Decode a message
+decoded_msg_obj = HelloWorldMessage.decode(encoded_msg)
+# decoded_msg == HelloWorldMessage(msg='Hello world!')
+
+decoded_dict = decoded_msg_obj.to_dict()
+# decoded_dict == {'msg': 'Hello world!'}
+
 ```
 
 Refer to the [Schema Representation][schema] for detailed explanation on schema formats accepted by MiniPB.
@@ -89,7 +114,7 @@ mpy-cross -s logging.py -O3 micropython-lib/logging/logging.py -o /your/PYBFLASH
 mpy-cross -s bisect.py -O3 micropython-lib/bisect/bisect.py -o /your/PYBFLASH/bisect.mpy
 ```
 
-## Usage
+## Usage - Format String and Key Value Schema
 
 Format string documentation can be found under the project [Wiki][wiki]. The module's pydoc contains some useful information on the API too.
 
@@ -97,3 +122,44 @@ Format string documentation can be found under the project [Wiki][wiki]. The mod
 [wiki]: https://github.com/dogtopus/minipb/wiki
 [schema]: https://github.com/dogtopus/minipb/wiki/Schema-Representations
 [mpydoc]: http://docs.micropython.org/en/latest/reference/packages.html
+
+## Usage - Message class
+Translating a proto into a Message class
+```protobuf
+    message Person {
+      required string name = 1; // *U
+      required int32 id = 2; // *t
+      optional string email = 3; // U
+
+      // enums are not supported natively in minipb. Use enums.IntEnum with a int field instead.
+      enum PhoneType {
+        MOBILE = 0;
+        HOME = 1;
+        WORK = 2;
+      }
+
+      message PhoneNumber { // [
+        required string number = 1; // *U
+        optional PhoneType type = 2 [default = HOME]; // t
+      } // ]
+
+      repeated PhoneNumber phone = 4; // +[*Ut]
+    }
+```
+
+```python
+from minipb import TYPE_STRING, TYPE_INT32, process_message_fields, Message, Field
+
+@process_message_fields
+class Person(Message):
+    name   = Field(1, TYPE_STRING, required=True)
+    id     = Field(2, TYPE_INT32, required=True)
+    email  = Field(3, TYPE_STRING)
+
+    @process_message_fields
+    class PhoneNumber(Message):
+        number = Field(1, TYPE_STRING, required=True)
+        type   = Field(2, TYPE_INT32)
+
+    phone  = Field(4, PhoneNumber, repeated=True)
+```

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import unittest
+import collections
 import minipb
 
 TEST_RAW_ENCODED = b'\x08\x7b\x12\x04\x74\x65\x73\x74\x1a\x0b\x0a\x06\x73\x74\x72\x69\x6e\x67\x10\xf8\x06\x1a\x13\x0a\x0e\x61\x6e\x6f\x74\x68\x65\x72\x5f\x73\x74\x72\x69\x6e\x67\x10\xb9\x60'
@@ -405,9 +406,9 @@ class TestMiniPB(unittest.TestCase):
             @minipb.process_message_fields
             class NestedMessage(minipb.Message):
                 str2 = minipb.Field(1, minipb.TYPE_STRING)
-                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+                num2 = minipb.Field(2, minipb.TYPE_UINT)
 
-            number = minipb.Field(1, minipb.TYPE_UINT32)
+            number = minipb.Field(1, minipb.TYPE_UINT)
             string = minipb.Field(2, minipb.TYPE_STRING)
             nested = minipb.Field(3, NestedMessage)
 
@@ -417,7 +418,7 @@ class TestMiniPB(unittest.TestCase):
             ('nested', (('str2', 'U'),
                         ('num2', 'T'),)),
         )
-        schema_from_msg = TestMessage.__minipb_kv_schema__
+        schema_from_msg = getattr(TestMessage, minipb._MESSAGE_KV_SCHEMA)
         self.assertEqual(schema_from_msg, schema)
 
     def test_msg_fields_to_kvfmt_very_complex(self):
@@ -426,9 +427,9 @@ class TestMiniPB(unittest.TestCase):
             @minipb.process_message_fields
             class NestedMessage(minipb.Message):
                 str2 = minipb.Field(1, minipb.TYPE_STRING)
-                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+                num2 = minipb.Field(2, minipb.TYPE_UINT)
 
-            number = minipb.Field(1, minipb.TYPE_UINT32)
+            number = minipb.Field(1, minipb.TYPE_UINT)
             string = minipb.Field(2, minipb.TYPE_STRING)
             nested = minipb.Field(3, NestedMessage, repeated=True)
 
@@ -438,8 +439,23 @@ class TestMiniPB(unittest.TestCase):
             ('nested', '+[', (('str2', 'U'),
                               ('num2', 'T'),)),
         )
-        schema_from_msg = TestMessage.__minipb_kv_schema__
+        schema_from_msg = getattr(TestMessage, minipb._MESSAGE_KV_SCHEMA)
         self.assertEqual(schema_from_msg, schema)
+
+    def _msg_from_raw_obj_with_nested(self):
+        n1 = collections.OrderedDict()
+        n1['str2'] = 'string'
+        n1['num2'] = 888
+
+        n2 = collections.OrderedDict()
+        n2['str2'] = 'another_string'
+        n2['num2'] = 12345
+
+        raw_obj = collections.OrderedDict()
+        raw_obj['number'] = 123
+        raw_obj['string'] = 'test'
+        raw_obj['nested'] = (n1, n2)
+        return raw_obj
 
     def test_msg_init_to_dict_very_complex(self):
         @minipb.process_message_fields
@@ -447,32 +463,20 @@ class TestMiniPB(unittest.TestCase):
             @minipb.process_message_fields
             class NestedMessage(minipb.Message):
                 str2 = minipb.Field(1, minipb.TYPE_STRING)
-                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+                num2 = minipb.Field(2, minipb.TYPE_UINT)
 
-            number = minipb.Field(1, minipb.TYPE_UINT32)
+            number = minipb.Field(1, minipb.TYPE_UINT)
             string = minipb.Field(2, minipb.TYPE_STRING)
             nested = minipb.Field(3, NestedMessage, repeated=True)
 
-        raw_obj = {
-            'number': 123,
-            'string': 'test',
-            'nested': (
-                {
-                    'str2': 'string',
-                    'num2': 888,
-                }, {
-                    'str2': 'another_string',
-                    'num2': 12345,
-                },
-            ),
-        }
+        raw_obj = self._msg_from_raw_obj_with_nested()
         test_msg = TestMessage(
             number=123,
             string='test',
             nested=[TestMessage.NestedMessage(**nested_dict) for nested_dict in raw_obj['nested']]
         )
         current_dict = test_msg.to_dict()
-        self.assertEquals(current_dict, raw_obj)
+        self.assertEqual(current_dict, raw_obj)
 
     def test_msg_from_dict_to_dict_roundtrip(self):
         @minipb.process_message_fields
@@ -480,25 +484,15 @@ class TestMiniPB(unittest.TestCase):
             @minipb.process_message_fields
             class NestedMessage(minipb.Message):
                 str2 = minipb.Field(1, minipb.TYPE_STRING)
-                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+                num2 = minipb.Field(2, minipb.TYPE_UINT)
 
-            number = minipb.Field(1, minipb.TYPE_UINT32)
+            number = minipb.Field(1, minipb.TYPE_UINT)
             string = minipb.Field(2, minipb.TYPE_STRING)
             nested = minipb.Field(3, NestedMessage, repeated=True)
 
-        raw_obj = {
-            'number': 123,
-            'string': 'test',
-            'nested': (
-                {
-                    'str2': 'string',
-                    'num2': 888,
-                }, {
-                    'str2': 'another_string',
-                    'num2': 12345,
-                },
-            ),
-        }
+
+        raw_obj = self._msg_from_raw_obj_with_nested()
+
         test_msg = TestMessage.from_dict(raw_obj)
         test_dict = test_msg.to_dict()
         self.assertEqual(test_dict, raw_obj)
@@ -520,25 +514,14 @@ class TestMiniPB(unittest.TestCase):
             @minipb.process_message_fields
             class NestedMessage(minipb.Message):
                 str2 = minipb.Field(1, minipb.TYPE_STRING)
-                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+                num2 = minipb.Field(2, minipb.TYPE_UINT)
 
-            number = minipb.Field(1, minipb.TYPE_UINT32)
+            number = minipb.Field(1, minipb.TYPE_UINT)
             string = minipb.Field(2, minipb.TYPE_STRING)
             nested = minipb.Field(3, NestedMessage, repeated=True)
 
-        raw_obj = {
-            'number': 123,
-            'string': 'test',
-            'nested': (
-                {
-                    'str2': 'string',
-                    'num2': 888,
-                }, {
-                    'str2': 'another_string',
-                    'num2': 12345,
-                },
-            ),
-        }
+        raw_obj = self._msg_from_raw_obj_with_nested()
+
         test_msg = TestMessage.from_dict(raw_obj)
         test_pb = test_msg.encode()
         self.assertEqual(test_pb, expected_pb)
@@ -551,15 +534,15 @@ class TestMiniPB(unittest.TestCase):
         @minipb.process_message_fields
         class BaseMessage(minipb.Message):
             zbase_str = minipb.Field(1, minipb.TYPE_STRING)
-            zbase_num = minipb.Field(2, minipb.TYPE_UINT32)
+            zbase_num = minipb.Field(2, minipb.TYPE_UINT)
 
         @minipb.process_message_fields
         class TestMessage(BaseMessage):
-            test_num = minipb.Field(3, minipb.TYPE_UINT32)
+            test_num = minipb.Field(3, minipb.TYPE_UINT)
             test_str = minipb.Field(4, minipb.TYPE_STRING)
 
         name_to_fields_map = getattr(TestMessage, minipb._MESSAGE_FIELDS_MAP)
-        self.assertEqual(name_to_fields_map['test_num'].type, minipb.TYPE_UINT32)
+        self.assertEqual(name_to_fields_map['test_num'].type, minipb.TYPE_UINT)
 
         expected_field_names = ('zbase_str', 'zbase_num', 'test_num', 'test_str')
         self.assertEqual(tuple(name_to_fields_map.keys()), expected_field_names)

--- a/test.py
+++ b/test.py
@@ -398,5 +398,172 @@ class TestMiniPB(unittest.TestCase):
         self.assertIn('Multiple definitions found', details.exception.args[0])
         self.assertIn('more fields after it', details.exception.args[0])
 
+
+    def test_msg_fields_to_kvfmt_complex(self):
+        @minipb.process_message_fields
+        class TestMessage(minipb.Message):
+            @minipb.process_message_fields
+            class NestedMessage(minipb.Message):
+                str2 = minipb.Field(1, minipb.TYPE_STRING)
+                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+
+            number = minipb.Field(1, minipb.TYPE_UINT32)
+            string = minipb.Field(2, minipb.TYPE_STRING)
+            nested = minipb.Field(3, NestedMessage)
+
+        schema = (
+            ('number', 'T'),
+            ('string', 'U'),
+            ('nested', (('str2', 'U'),
+                        ('num2', 'T'),)),
+        )
+        schema_from_msg = TestMessage.__minipb_kv_schema__
+        self.assertEqual(schema_from_msg, schema)
+
+    def test_msg_fields_to_kvfmt_very_complex(self):
+        @minipb.process_message_fields
+        class TestMessage(minipb.Message):
+            @minipb.process_message_fields
+            class NestedMessage(minipb.Message):
+                str2 = minipb.Field(1, minipb.TYPE_STRING)
+                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+
+            number = minipb.Field(1, minipb.TYPE_UINT32)
+            string = minipb.Field(2, minipb.TYPE_STRING)
+            nested = minipb.Field(3, NestedMessage, repeated=True)
+
+        schema = (
+            ('number', 'T'),
+            ('string', 'U'),
+            ('nested', '+[', (('str2', 'U'),
+                              ('num2', 'T'),)),
+        )
+        schema_from_msg = TestMessage.__minipb_kv_schema__
+        self.assertEqual(schema_from_msg, schema)
+
+    def test_msg_init_to_dict_very_complex(self):
+        @minipb.process_message_fields
+        class TestMessage(minipb.Message):
+            @minipb.process_message_fields
+            class NestedMessage(minipb.Message):
+                str2 = minipb.Field(1, minipb.TYPE_STRING)
+                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+
+            number = minipb.Field(1, minipb.TYPE_UINT32)
+            string = minipb.Field(2, minipb.TYPE_STRING)
+            nested = minipb.Field(3, NestedMessage, repeated=True)
+
+        raw_obj = {
+            'number': 123,
+            'string': 'test',
+            'nested': (
+                {
+                    'str2': 'string',
+                    'num2': 888,
+                }, {
+                    'str2': 'another_string',
+                    'num2': 12345,
+                },
+            ),
+        }
+        test_msg = TestMessage(
+            number=123,
+            string='test',
+            nested=[TestMessage.NestedMessage(**nested_dict) for nested_dict in raw_obj['nested']]
+        )
+        current_dict = test_msg.to_dict()
+        self.assertEquals(current_dict, raw_obj)
+
+    def test_msg_from_dict_to_dict_roundtrip(self):
+        @minipb.process_message_fields
+        class TestMessage(minipb.Message):
+            @minipb.process_message_fields
+            class NestedMessage(minipb.Message):
+                str2 = minipb.Field(1, minipb.TYPE_STRING)
+                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+
+            number = minipb.Field(1, minipb.TYPE_UINT32)
+            string = minipb.Field(2, minipb.TYPE_STRING)
+            nested = minipb.Field(3, NestedMessage, repeated=True)
+
+        raw_obj = {
+            'number': 123,
+            'string': 'test',
+            'nested': (
+                {
+                    'str2': 'string',
+                    'num2': 888,
+                }, {
+                    'str2': 'another_string',
+                    'num2': 12345,
+                },
+            ),
+        }
+        test_msg = TestMessage.from_dict(raw_obj)
+        test_dict = test_msg.to_dict()
+        self.assertEqual(test_dict, raw_obj)
+
+        test_msg_from_dict_again = TestMessage.from_dict(test_dict)
+        self.assertEqual(test_msg_from_dict_again, test_msg)
+
+        # Confirm sure these are different instances
+        self.assertNotEqual(id(test_msg_from_dict_again), id(test_msg))
+
+        test_dict_rt = test_msg_from_dict_again.to_dict()
+        self.assertEqual(test_dict_rt, raw_obj)
+
+    def test_msg_encode_decode_roundtrip(self):
+        expected_pb = b'\x08\x7b\x12\x04\x74\x65\x73\x74\x1a\x0b\x0a\x06\x73\x74\x72\x69\x6e\x67\x10\xf8\x06\x1a\x13\x0a\x0e\x61\x6e\x6f\x74\x68\x65\x72\x5f\x73\x74\x72\x69\x6e\x67\x10\xb9\x60'
+
+        @minipb.process_message_fields
+        class TestMessage(minipb.Message):
+            @minipb.process_message_fields
+            class NestedMessage(minipb.Message):
+                str2 = minipb.Field(1, minipb.TYPE_STRING)
+                num2 = minipb.Field(2, minipb.TYPE_UINT32)
+
+            number = minipb.Field(1, minipb.TYPE_UINT32)
+            string = minipb.Field(2, minipb.TYPE_STRING)
+            nested = minipb.Field(3, NestedMessage, repeated=True)
+
+        raw_obj = {
+            'number': 123,
+            'string': 'test',
+            'nested': (
+                {
+                    'str2': 'string',
+                    'num2': 888,
+                }, {
+                    'str2': 'another_string',
+                    'num2': 12345,
+                },
+            ),
+        }
+        test_msg = TestMessage.from_dict(raw_obj)
+        test_pb = test_msg.encode()
+        self.assertEqual(test_pb, expected_pb)
+
+        decoded_msg = TestMessage.decode(expected_pb)
+        self.assertEqual(decoded_msg, test_msg)
+
+
+    def test_msg_inherited_fields(self):
+        @minipb.process_message_fields
+        class BaseMessage(minipb.Message):
+            zbase_str = minipb.Field(1, minipb.TYPE_STRING)
+            zbase_num = minipb.Field(2, minipb.TYPE_UINT32)
+
+        @minipb.process_message_fields
+        class TestMessage(BaseMessage):
+            test_num = minipb.Field(3, minipb.TYPE_UINT32)
+            test_str = minipb.Field(4, minipb.TYPE_STRING)
+
+        name_to_fields_map = getattr(TestMessage, minipb._MESSAGE_FIELDS_MAP)
+        self.assertEqual(name_to_fields_map['test_num'].type, minipb.TYPE_UINT32)
+
+        expected_field_names = ('zbase_str', 'zbase_num', 'test_num', 'test_str')
+        self.assertEqual(tuple(name_to_fields_map.keys()), expected_field_names)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow schemas to be defined via ORM-like methods - via Message and Field classes

- Field class introduces field_number for ordering purposes but is NOT used in encoding/decoding operations
- Utilizes decorators instead of metaclasses to maintain capability with MicroPython
- String Format chars promoted to TYPE_* const's used in the Field class ('U' => TYPE_STRING)
- Cleaned up usage of classmethods and staticmethods
