### PR TITLE
Support non-sequential field numbers via the Message/Field format

### DIFF
--- a/minipb.py
+++ b/minipb.py
@@ -22,8 +22,14 @@ import re
 import struct
 import io
 
+mod_logger = logging.getLogger('minipb')
+
 _IS_MPY = __import__('sys').implementation.name == 'micropython'
-# In order of https://protobuf.dev/programming-guides/proto3/
+
+#
+# Protocol Buffer types, as used in minipb
+# https://protobuf.dev/programming-guides/proto3/
+#
 TYPE_DOUBLE = 'd'
 TYPE_FLOAT = 'f'
 TYPE_INT = 't'
@@ -46,29 +52,51 @@ TYPE_UINT64 = TYPE_UINT
 TYPE_SINT32 = TYPE_SINT
 TYPE_SINT64 = TYPE_SINT
 
-
-_TYPE_VARINTS = ''.join([TYPE_INT, TYPE_UINT, TYPE_SINT, TYPE_BOOL])
-_TYPE_FIXED_LEN = ''.join([TYPE_SFIXED32, TYPE_FIXED32, TYPE_FLOAT, TYPE_DOUBLE, TYPE_SFIXED64, TYPE_FIXED64])
-
-# Wire Types - https://protobuf.dev/programming-guides/encoding/#structure
-_WIRE_TYPE_VARINT = 0
-_WIRE_TYPE_I64 = 1
-_WIRE_TYPE_LEN = 2
-_WIRE_TYPE_I32 = 5
-
 TYPES = frozenset([
     TYPE_DOUBLE, TYPE_FLOAT, TYPE_INT, TYPE_UINT, TYPE_SINT, TYPE_FIXED32, TYPE_FIXED64, TYPE_SFIXED32, TYPE_SFIXED64, TYPE_BOOL, TYPE_STRING, TYPE_BYTES, TYPE_EMPTY,
     'v', 'V', 'l', 'L'
 ])
 
-# MiniPB specific Prefixes
-PREFIX_REQUIRED = '*'
-PREFIX_REPEATED = '+'
-PREFIX_REPEATED_PACKED = '#'
-PREFIX_MESSAGE = '['
+#
+# Protocol Buffer wire types, defined in official documentation
+# https://protobuf.dev/programming-guides/encoding/#structure
+# 
+_WIRE_TYPE_VARINT = 0
+_WIRE_TYPE_I64 = 1
+_WIRE_TYPE_LEN = 2
+_WIRE_TYPE_I32 = 5
 
-SUFFIX_MESSAGE = ']'
+#
+# Protocol Buffer Type to Wire Type mapping, defined in official documentation
+# https://protobuf.dev/programming-guides/encoding/#structure
+#
+_TYPE_TO_WIRE_TYPE_MAP = {
+    # VARINT
+    TYPE_INT: _WIRE_TYPE_VARINT,
+    TYPE_UINT: _WIRE_TYPE_VARINT,
+    TYPE_SINT: _WIRE_TYPE_VARINT,
+    TYPE_BOOL: _WIRE_TYPE_VARINT,
 
+    # I64
+    TYPE_FIXED64: _WIRE_TYPE_I64,
+    TYPE_SFIXED64: _WIRE_TYPE_I64,
+    TYPE_DOUBLE: _WIRE_TYPE_I64,
+
+    # LEN
+    TYPE_STRING: _WIRE_TYPE_LEN,
+    TYPE_BYTES: _WIRE_TYPE_LEN,
+
+    # I32
+    TYPE_FIXED32: _WIRE_TYPE_I32,
+    TYPE_SFIXED32: _WIRE_TYPE_I32,
+    TYPE_FLOAT: _WIRE_TYPE_I32,
+
+    TYPE_EMPTY: None
+}
+
+#
+# Errors raised by minipb
+# 
 class BadFormatString(ValueError):
     """
     Malformed format string
@@ -106,6 +134,9 @@ else:
     def _get_length_of_match(m):
         return m.end()
 
+#
+# Encoders/Decoders for Protocol Buffer's basic types
+#
 def _encode_vint(number):
     """
     Encode a number to vint (Wire Type 0).
@@ -191,26 +222,6 @@ def _vint_dezigzagify(number):
         num = ~num
     return num
 
-def _encode_header(f_type, f_id):
-    """
-    Encode a header
-    Called internally in _encode_wire() function
-    """
-    hdr = (f_id << 3) | f_type
-    return _encode_vint(hdr)
-
-def _decode_header(buf):
-    """
-    Decode field header.
-    Raises EndOfMessage if there is no or only partial data available.
-    Called internally in decode() method
-    """
-    ord_data = _decode_vint(buf)
-    f_type = ord_data & 7
-    f_id = ord_data >> 3
-    return f_type, f_id
-
-
 def _encode_bytes(in_bytes):
     """
     Encode a string/binary stream into protobuf variable length by
@@ -233,10 +244,107 @@ def _decode_bytes(buf):
         raise EndOfMessage(True)
     return result
 
+def _encode_fixed_length_numerical(field_type, py_data, mask=None):
+    return struct.pack('<{0}'.format(field_type), py_data)
+
+def _decode_fixed_length_numerical(field_type, field_bytes, max_bits=None, mask=None):
+    return struct.unpack('<{0}'.format(field_type), field_bytes)[0]
+        
+
+_TYPE_TO_ENCODER_MAP = {
+    TYPE_BYTES:    lambda t, py_data, mask: _encode_bytes(py_data),
+    TYPE_STRING:   lambda t, py_data, mask: _encode_bytes(py_data.encode('utf-8')),
+    TYPE_INT:      lambda t, py_data, mask: _encode_vint(_vint_signedto2sc(py_data, mask=mask)),
+    TYPE_UINT:     lambda t, py_data, mask: _encode_vint(py_data),
+    TYPE_SINT:     lambda t, py_data, mask: _encode_vint(_vint_zigzagify(py_data)),
+    TYPE_BOOL:     lambda t, py_data, mask: _encode_vint(int(py_data)),
+    TYPE_SFIXED32: _encode_fixed_length_numerical,
+    TYPE_FIXED32:  _encode_fixed_length_numerical,
+    TYPE_FLOAT:    _encode_fixed_length_numerical,
+    TYPE_DOUBLE:   _encode_fixed_length_numerical,
+    TYPE_SFIXED64: _encode_fixed_length_numerical,
+    TYPE_FIXED64:  _encode_fixed_length_numerical
+}
+
+_TYPE_TO_DECODER_MAP = {
+    TYPE_BYTES:    lambda t, f_data, max_bits, mask: f_data,
+    TYPE_STRING:   lambda t, f_data, max_bits, mask: f_data.decode('utf-8'),
+    TYPE_INT:      lambda t, f_data, max_bits, mask: _vint_2sctosigned(f_data, max_bits=max_bits, mask=mask),
+    TYPE_UINT:     lambda t, f_data, max_bits, mask: f_data,
+    TYPE_SINT:     lambda t, f_data, max_bits, mask: _vint_dezigzagify(f_data),
+    TYPE_BOOL:     lambda t, f_data, max_bits, mask: bool(f_data != 0),
+    TYPE_SFIXED32: _decode_fixed_length_numerical,
+    TYPE_FIXED32:  _decode_fixed_length_numerical,
+    TYPE_FLOAT:    _decode_fixed_length_numerical,
+    TYPE_DOUBLE:   _decode_fixed_length_numerical,
+    TYPE_SFIXED64: _decode_fixed_length_numerical,
+    TYPE_FIXED64:  _decode_fixed_length_numerical
+}
+def _encode_scalar_to_bytes(field_type, py_data, mask=_DEFAULT_VINT_2SC_MASK):
+    """
+    Encode a single field to binary wire format, without field_number and wire_type headers
+    
+    This method does NOT support nested Messages
+    """
+    encoder_fxn = _TYPE_TO_ENCODER_MAP.get(field_type)
+    if not encoder_fxn:
+        raise TypeError('unknown type: {}'.format(field_type))
+
+    return encoder_fxn(field_type, py_data, mask)
+
+def _decode_scalar_from_bytes(field_type, f_data, max_bits=_DEFAULT_VINT_2SC_MAX_BITS, mask=_DEFAULT_VINT_2SC_MASK):
+    """
+    Decode a single field, without field_number and wire_type headers
+
+    This method does NOT support nested Messages
+    """
+    decoder_fxn = _TYPE_TO_DECODER_MAP.get(field_type)
+    if not decoder_fxn:
+        raise TypeError('unknown type: {}'.format(field_type))
+
+    return decoder_fxn(field_type, f_data, max_bits=max_bits, mask=mask)
+
+#
+# Helper functions when processing Protocol Buffer Wire formats without schemas
+#
+def _encode_header(f_type, f_id):
+    """
+    Encode a header
+    Called internally in _encode_wire() function
+    """
+    hdr = (f_id << 3) | f_type
+    return _encode_vint(hdr)
+
+def _decode_header(buf):
+    """
+    Decode field header.
+    Raises EndOfMessage if there is no or only partial data available.
+    Called internally in decode() method
+    """
+    ord_data = _decode_vint(buf)
+    f_type = ord_data & 7
+    f_id = ord_data >> 3
+    return f_type, f_id
+
+def _check_bytes_length(data, length):
+    if not hasattr(data, 'decode'):
+        raise ValueError(
+            'Excepted a bytes object, not {}'.format(
+                type(data).__name__
+            )
+        )
+    elif len(data) != length:
+        raise ValueError(
+            'Excepted a bytes object of length {}, got {}'.format(
+                length, len(data)
+            )
+        )
+    return data
+
 def _read_fixed(buf, length):
     """
     Read out a fixed type and report if the result is incomplete.
-    Called internally in _break_down().
+    Called internally in _yield_fields_from_wire().
     """
     result = buf.read(length)
     actual = len(result)
@@ -244,9 +352,109 @@ def _read_fixed(buf, length):
         raise EndOfMessage(False if actual == 0 else True)
     return result
 
-def _index_fields(decoded_raw):
+
+_WIRE_TYPE_TO_ENCODER_MAP = {
+    _WIRE_TYPE_VARINT: _encode_vint,
+    _WIRE_TYPE_I64:    lambda n: _check_bytes_length(n, 8),
+    _WIRE_TYPE_LEN:    _encode_bytes,
+    _WIRE_TYPE_I32:    lambda n: _check_bytes_length(n, 4)
+}
+
+_WIRE_TYPE_TO_DECODER_MAP = {
+    _WIRE_TYPE_VARINT:  _decode_vint,
+    _WIRE_TYPE_I64:     lambda n: _read_fixed(n, 8),
+    _WIRE_TYPE_LEN:     _decode_bytes,
+    _WIRE_TYPE_I32:     lambda n: _read_fixed(n, 4)
+}
+def _yield_fields_from_wire(buf, wire_type=None, field_number=None):
     """
-    Build an index for the fields decoded by _break_down().
+    Helper method to 'break down' a wire string into a list for
+    further processing.
+    Pass type_override and id_override to decompose headerless wire
+    strings. (Mainly used for unpacking packed repeated fields)
+    Called internally in _decode_wire() function
+    """
+    assert (field_number is not None and wire_type is not None) or\
+            (field_number is None and wire_type is None),\
+        'Field ID and type must be both specified in headerless mode'
+
+    requires_header_decoding = (wire_type is None and field_number is None)
+    while 1:
+        field = {}
+        if requires_header_decoding:
+            # if no more data, stop and return
+            try:
+                wire_type, field_number = _decode_header(buf)
+            except EOFError:
+                break
+
+        wt_decoder = _WIRE_TYPE_TO_DECODER_MAP.get(wire_type)
+        if not wt_decoder:
+            mod_logger.warning(
+                "_yield_fields_from_wire():Ignore unknown type #%d", wire_type
+            )
+            continue
+        try:
+            f_data = wt_decoder(buf)
+        except EndOfMessage as e:
+            if wire_type is None or e.partial:
+                raise CodecError('Unexpected end of message while decoding field {0}'.format(field_number)) from e
+            else:
+                break
+        field['id'] = field_number
+        field['wire_type'] = wire_type
+        field['data'] = f_data
+        yield field
+
+def encode_raw(objs):
+    """
+    Encode a list of raw data and types to binary wire format
+    Useful for analyzing Protobuf messages with unknown schema
+
+    Encode the output of decode_raw() back to binary wire format
+    """
+    encoded = io.BytesIO()
+    for s in objs:
+        wire_type = s['wire_type']
+        encoded.write(_encode_header(wire_type, s['id']))
+        current_encoder = _WIRE_TYPE_TO_ENCODER_MAP.get(wire_type)
+        if not current_encoder:
+            raise ValueError('Unknown type {}'.format(wire_type))
+        encoded.write(current_encoder(s['data']))
+
+    return encoded.getvalue()
+
+
+def decode_raw(data):
+    """
+    Decode given binary wire to a list of raw data and types
+    Useful for analyzing Protobuf messages with unknown schema
+
+    Decode wire data to a list of dicts that contain raw wire data and types
+    The dictionary contains 3 keys:
+        - id: The field number that the data belongs to
+        - wire_type: Wire type of that field, see
+            https://developers.google.com/protocol-buffers/docs/encoding
+            for the list of wire types (currently type 3 and 4 are not
+            supported)
+        - data: The raw data of the field. Note that data with wire type 0
+            (vints) are always decoded as unsigned Two's Complement format
+            regardless of ZigZag encoding was being used (which also means
+            they will always be positive) and wire type 1 and 5 (fixed-length)
+            are decoded as bytes of fixed length (i.e. 8 bytes for type 1 and
+            4 bytes for type 5)
+    """
+    if not hasattr(data, 'read'):
+        data = io.BytesIO(data)
+
+    return tuple(_yield_fields_from_wire(data))
+
+#
+# Characters explicitly used in minipb's format_string and kvfmt schema 
+#
+def _group_fields_by_number(decoded_raw):
+    """
+    Build an index for the fields decoded by _yield_fields_from_wire().
     Called internally in _decode_wire().
     """
     index = {}
@@ -272,6 +480,12 @@ def _concat_fields(fields):
     result['data'] = result_wire.getvalue()
     return result
 
+PREFIX_REQUIRED = '*'
+PREFIX_REPEATED = '+'
+PREFIX_REPEATED_PACKED = '#'
+PREFIX_MESSAGE = '['
+
+SUFFIX_MESSAGE = ']'
 class _OverlapCheck:
     '''
     Check overlaps of fields and keep track used field intervals.
@@ -360,30 +574,6 @@ class _OverlapCheck:
 
 
 class Wire:
-    # Field types - https://protobuf.dev/programming-guides/encoding/#structure
-    _FIELD_WIRE_TYPE = {
-        # VARINT
-        TYPE_INT: _WIRE_TYPE_VARINT,
-        TYPE_UINT: _WIRE_TYPE_VARINT,
-        TYPE_SINT: _WIRE_TYPE_VARINT,
-        TYPE_BOOL: _WIRE_TYPE_VARINT,
-
-        # I64
-        TYPE_FIXED64: _WIRE_TYPE_I64,
-        TYPE_SFIXED64: _WIRE_TYPE_I64,
-        TYPE_DOUBLE: _WIRE_TYPE_I64,
-
-        # LEN
-        TYPE_STRING: _WIRE_TYPE_LEN,
-        TYPE_BYTES: _WIRE_TYPE_LEN,
-
-        # I32
-        TYPE_FIXED32: _WIRE_TYPE_I32,
-        TYPE_SFIXED32: _WIRE_TYPE_I32,
-        TYPE_FLOAT: _WIRE_TYPE_I32,
-
-        TYPE_EMPTY: None
-    }
     # Field aliases
     _FIELD_ALIAS = {
         'v': TYPE_SINT, 'V': TYPE_UINT,
@@ -394,7 +584,7 @@ class Wire:
     # wire type, # of repeat and field seek
     _T_FMT = re.compile(
         r"^(?:({0})|({1}))(\d*)(?:@(\d+))?".format(
-            '|'.join(_FIELD_WIRE_TYPE.keys()),
+            '|'.join(_TYPE_TO_WIRE_TYPE_MAP.keys()),
             '|'.join(_FIELD_ALIAS.keys())
         )
     )
@@ -418,7 +608,7 @@ class Wire:
         self.vint_2sc_max_bits = vint_2sc_max_bits or self._VINT_MAX_BITS
 
         if isinstance(fmt, str):
-            self._fmt = self._parse(fmt)
+            self._fmt = self._parse_format_string(fmt)
             self._kv_fmt = False
         else:
             self._fmt = self._parse_kvfmt(fmt)
@@ -445,7 +635,7 @@ class Wire:
 
     def _parse_kvfmt(self, fmtlist):
         """
-        Similar to _parse() but for key-value format lists.
+        Similar to _parse_format_string() but for key-value format lists.
         """
         t_fmt = self._T_FMT
         t_prefix = self._T_PREFIX
@@ -523,7 +713,7 @@ class Wire:
 
         return parsed_list
 
-    def _parse(self, fmtstr):
+    def _parse_format_string(self, fmtstr):
         """
         Parse format string to something more machine readable.
         Called internally inside the class.
@@ -579,7 +769,7 @@ class Wire:
                             'Unmatched brace on position {0}'.format(ptr)
                         )
                     parsed['field_type'] = TYPE_BYTES
-                    parsed['subcontent'] = self._parse(
+                    parsed['subcontent'] = self._parse_format_string(
                         fmtstr[ptr:brace_offset]
                     )
                     ptr = brace_offset + 1
@@ -649,38 +839,8 @@ class Wire:
 
     @classmethod
     def encode_raw(cls, stuff):
-        '''
-        Encode the output of decode_raw() back to binary wire format
-        '''
-        def _check_bytes_length(data, length):
-            if not hasattr(data, 'decode'):
-                raise ValueError(
-                    'Excepted a bytes object, not {}'.format(
-                        type(data).__name__
-                    )
-                )
-            elif len(data) != length:
-                raise ValueError(
-                    'Excepted a bytes object of length {}, got {}'.format(
-                        length, len(data)
-                    )
-                )
-            return data
+        return encode_raw(stuff)
 
-        ENCODERS = {
-            0: _encode_vint,
-            1: lambda n: _check_bytes_length(n, 8),
-            2: _encode_bytes,
-            5: lambda n: _check_bytes_length(n, 4)
-        }
-        encoded = io.BytesIO()
-        for s in stuff:
-            encoded.write(_encode_header(s['wire_type'], s['id']))
-            if s['wire_type'] not in ENCODERS.keys():
-                raise ValueError('Unknown type {}'.format(s['wire_type']))
-            encoded.write(ENCODERS[s['wire_type']](s['data']))
-
-        return encoded.getvalue()
 
     def _encode_wire(self, stuff, fmtable=None):
         """
@@ -715,7 +875,7 @@ class Wire:
 
                 prefix = fmt['prefix']
                 subcontent = fmt.get('subcontent')
-                wire_type = self._FIELD_WIRE_TYPE[fmt['field_type']]
+                wire_type = _TYPE_TO_WIRE_TYPE_MAP[field_type]
 
                 #self.logger.debug(
                 #    '_encode_wire(): Encoding field #%d type %s prefix %s',
@@ -728,12 +888,9 @@ class Wire:
 
                 # Packed repeating field always has a str-like header
                 if prefix == PREFIX_REPEATED_PACKED:
-                    encoded_header = _encode_header(
-                        _WIRE_TYPE_LEN,
-                        field_id
-                    )
-                else:
-                    encoded_header = _encode_header(wire_type, field_id)
+                    wire_type = _WIRE_TYPE_LEN
+
+                encoded_header = _encode_header(wire_type, field_id)
 
                 # Empty required field
                 if prefix == PREFIX_REQUIRED and field_data == None:
@@ -777,7 +934,7 @@ class Wire:
 
     def _encode_field(self, field_type, field_data, subcontent=None):
         """
-        Encode a single field to binary wire format
+        Encode a single field to binary wire format, without field_number and wire_type headers
         Called internally in _encode_wire() function
         """
         #self.logger.debug(
@@ -792,29 +949,9 @@ class Wire:
             field_encoded = _encode_bytes(
                 self._encode_wire(field_data, subcontent).read()
             )
-        # bytes
-        elif field_type == TYPE_BYTES:
-            field_encoded = _encode_bytes(field_data)
-
-        # strings
-        elif field_type == TYPE_STRING:
-            field_encoded = _encode_bytes(field_data.encode('utf-8'))
-
-        # vint family (signed, unsigned and boolean)
-        elif field_type in _TYPE_VARINTS:
-            if field_type == TYPE_INT:
-                field_data = _vint_signedto2sc(field_data, mask=self._vint_2sc_mask)
-            elif field_type == TYPE_SINT:
-                field_data = _vint_zigzagify(field_data)
-            elif field_type == TYPE_BOOL:
-                field_data = int(field_data)
-            field_encoded = _encode_vint(field_data)
-
-        # fixed numerical value
-        elif field_type in _TYPE_FIXED_LEN:
-            field_encoded = struct.pack(
-                '<{0}'.format(field_type), field_data
-            )
+        # everything else
+        else:
+            field_encoded = _encode_scalar_to_bytes(field_type, field_data, mask=self._vint_2sc_mask)
 
         return field_encoded
 
@@ -836,78 +973,7 @@ class Wire:
 
     @classmethod
     def decode_raw(cls, data):
-        '''
-        Decode wire data to a list of dicts that contain raw wire data and types
-        The dictionary contains 3 keys:
-            - id: The field number that the data belongs to
-            - wire_type: Wire type of that field, see
-              https://developers.google.com/protocol-buffers/docs/encoding
-              for the list of wire types (currently type 3 and 4 are not
-              supported)
-            - data: The raw data of the field. Note that data with wire type 0
-              (vints) are always decoded as unsigned Two's Complement format
-              regardless of ZigZag encoding was being used (which also means
-              they will always be positive) and wire type 1 and 5 (fixed-length)
-              are decoded as bytes of fixed length (i.e. 8 bytes for type 1 and
-              4 bytes for type 5)
-        '''
-        if not hasattr(data, 'read'):
-            data = io.BytesIO(data)
-
-        return tuple(cls._break_down(data))
-
-
-
-    @classmethod
-    def _break_down(cls, buf, type_override=None, id_override=None):
-        """
-        Helper method to 'break down' a wire string into a list for
-        further processing.
-        Pass type_override and id_override to decompose headerless wire
-        strings. (Mainly used for unpacking packed repeated fields)
-        Called internally in _decode_wire() function
-        """
-        assert (id_override is not None and type_override is not None) or\
-               (id_override is None and type_override is None),\
-            'Field ID and type must be both specified in headerless mode'
-
-        while 1:
-            field = {}
-            if type_override is not None:
-                f_type = type_override
-                f_id = id_override
-            else:
-                # if no more data, stop and return
-                try:
-                    f_type, f_id = _decode_header(buf)
-                except EOFError:
-                    break
-
-            #self.logger.debug(
-            #    "_break_down():field #%d pbtype #%d", f_id, f_type
-            #)
-            try:
-                if f_type == _WIRE_TYPE_VARINT: # vint
-                    field['data'] = _decode_vint(buf)
-                elif f_type == _WIRE_TYPE_I64: # 64-bit
-                    field['data'] = _read_fixed(buf, 8)
-                elif f_type == _WIRE_TYPE_LEN: # str
-                    field['data'] = _decode_bytes(buf)
-                elif f_type == _WIRE_TYPE_I32: # 32-bit
-                    field['data'] = _read_fixed(buf, 4)
-                else:
-                    cls.logger.warning(
-                        "_break_down():Ignore unknown type #%d", f_type
-                    )
-                    continue
-            except EndOfMessage as e:
-                if type_override is None or e.partial:
-                    raise CodecError('Unexpected end of message while decoding field {0}'.format(f_id)) from e
-                else:
-                    break
-            field['id'] = f_id
-            field['wire_type'] = f_type
-            yield field
+        return decode_raw(data)
 
     def _decode_field(self, field_type, field_data, subcontent=None):
         """
@@ -915,7 +981,7 @@ class Wire:
         Called internally in _decode_wire() function
         """
         # check wire type
-        wt_schema = self._FIELD_WIRE_TYPE[field_type]
+        wt_schema = _TYPE_TO_WIRE_TYPE_MAP[field_type]
         wt_data = field_data['wire_type']
         if wt_schema != wt_data:
             raise TypeError(
@@ -930,43 +996,17 @@ class Wire:
         # nested structure
         if field_type == TYPE_BYTES and subcontent:
             #self.logger.debug('_decode_field(): nested field begin')
+            field_decoded = self._decode_wire(
+                io.BytesIO(field_bytes),
+                subcontent
+            )
             if self._kv_fmt:
-                field_decoded = dict(self._decode_wire(
-                    io.BytesIO(field_bytes),
-                    subcontent
-                ))
+                field_decoded = dict(field_decoded)
             else:
-                field_decoded = tuple(self._decode_wire(
-                    io.BytesIO(field_bytes),
-                    subcontent
-                ))
+                field_decoded = tuple(field_decoded)
             #self.logger.debug('_decode_field(): nested field end')
-
-        # string, unsigned vint (2sc)
-        elif field_type == TYPE_BYTES or field_type == TYPE_UINT: # TYPE_UINT64 as well
-            field_decoded = field_bytes
-
-        # unicode
-        elif field_type == TYPE_STRING:
-            field_decoded = field_bytes.decode('utf-8')
-
-        # vint (zigzag)
-        elif field_type == TYPE_SINT: # TYPE_SINT64 as well
-            field_decoded = _vint_dezigzagify(field_bytes)
-
-        # signed 2sc
-        elif field_type == TYPE_INT: # TYPE_INT64 as well
-            field_decoded =  _vint_2sctosigned(field_bytes, max_bits=self._vint_2sc_max_bits, mask=self._vint_2sc_mask)
-
-        # fixed, float, double
-        elif field_type in _TYPE_FIXED_LEN:
-            field_decoded = struct.unpack(
-                '<{0}'.format(field_type), field_bytes
-            )[0]
-
-        # boolean
-        elif field_type == TYPE_BOOL:
-            field_decoded = bool(field_bytes != 0)
+        else:
+            field_decoded = _decode_scalar_from_bytes(field_type, field_bytes, max_bits=self._vint_2sc_max_bits, mask=self._vint_2sc_mask)
 
         return field_decoded
 
@@ -976,7 +1016,7 @@ class Wire:
         Used by the decode() method, may also be invoked by _decode_field()
         to decode nested structures
         """
-        decoded_raw_index = _index_fields(self._break_down(buf))
+        decoded_raw_index = _group_fields_by_number(_yield_fields_from_wire(buf))
         if not subfmt:
             subfmt = self._fmt
 
@@ -1036,10 +1076,10 @@ class Wire:
                             fmt['name'] if self._kv_fmt else field_id
                         ))
                     field = io.BytesIO(fields[0]['data'])
-                    unpacked_field = self._break_down(
+                    unpacked_field = _yield_fields_from_wire(
                         field,
-                        type_override=self._FIELD_WIRE_TYPE[field_type],
-                        id_override=field_id
+                        wire_type=_TYPE_TO_WIRE_TYPE_MAP[field_type],
+                        field_number=field_id
                     )
                     field_decoded = tuple(
                         self._decode_field(field_type, f, subcontent)
@@ -1088,24 +1128,12 @@ def decode(fmtstr, data):
     """Decode given binary wire to Python object(s) using fmtstr"""
     return Wire(fmtstr).decode(data)
 
-def encode_raw(objs):
-    """
-    Encode a list of raw data and types to binary wire format
-    Useful for analyzing Protobuf messages with unknown schema
-    """
-    return Wire.encode_raw(objs)
-
-def decode_raw(data):
-    """
-    Decode given binary wire to a list of raw data and types
-    Useful for analyzing Protobuf messages with unknown schema
-    """
-    return Wire.decode_raw(data)
 
 # Adding support for Message and Field to succinctly define Messages #####
-_MESSAGE_FIELDS_MAP = '_minipb_fields_map'
-_MESSAGE_KV_SCHEMA = '_minipb_kv_schema'
-_MESSAGE_WIRE = '_minipb_wire'
+_MESSAGE_NAME_TO_FIELDS_MAP = '__minipb_name_to_fields_map__'
+_MESSAGE_NUMBER_TO_FIELDS_MAP = '__minipb_number_to_fields_map__'
+_MESSAGE_KV_SCHEMA = '__minipb_kv_schema__'
+_MESSAGE_WIRE = '__minipb_wire__'
 
 class Field:
     """MiniPB Field inspired from dataclasses module
@@ -1123,7 +1151,6 @@ class Field:
         self.required = required
         self.repeated = repeated
         self.repeated_packed = repeated_packed
-
 
 def _kv_schema_from_fields(fields_map):
     """
@@ -1155,7 +1182,6 @@ def _kv_schema_from_fields(fields_map):
 
     return tuple(kv_schema)
 
-
 def process_message_fields(cls):
     # Identify all Fields
     name_to_fields_map = collections.OrderedDict()
@@ -1164,7 +1190,7 @@ def process_message_fields(cls):
     for current_base in cls.__bases__:
         # Only process classes that have been processed by our
         # decorator.  That is, they have a _FIELDS attribute.
-        base_fields_map = getattr(current_base, _MESSAGE_FIELDS_MAP, None)
+        base_fields_map = getattr(current_base, _MESSAGE_NAME_TO_FIELDS_MAP, None)
         if not base_fields_map:
             continue
 
@@ -1172,21 +1198,23 @@ def process_message_fields(cls):
             name_to_fields_map[attr_name] = current_field
 
     # Get Fields from this class declaration
-    number_and_field_list = []
+    number_to_fields_map = dict()
     for attr_name, current_field in cls.__dict__.items():
         if not isinstance(current_field, Field):
             continue
 
         # Splice in Field name since Field declaration didn't have this
         current_field.name = attr_name
-        number_and_field_list.append((current_field.number, current_field))
+        number_to_fields_map[current_field.number] = current_field
 
-    for _, current_field in sorted(number_and_field_list):
+    # Sort by Field Number
+    for _, current_field in sorted(number_to_fields_map.items()):
         name_to_fields_map[current_field.name] = current_field
 
     # Add in Message.Fields
     kv_schema = _kv_schema_from_fields(name_to_fields_map)
-    setattr(cls, _MESSAGE_FIELDS_MAP, name_to_fields_map)
+    setattr(cls, _MESSAGE_NAME_TO_FIELDS_MAP, name_to_fields_map)
+    setattr(cls, _MESSAGE_NUMBER_TO_FIELDS_MAP, number_to_fields_map)
     setattr(cls, _MESSAGE_KV_SCHEMA, kv_schema)
     setattr(cls, _MESSAGE_WIRE, Wire(kv_schema))
     return cls
@@ -1195,7 +1223,7 @@ def is_message(obj):
     """Returns True if obj is a dataclass or an instance of a
     dataclass."""
     cls = obj if isinstance(obj, type) else type(obj)
-    return hasattr(cls, _MESSAGE_FIELDS_MAP)
+    return hasattr(cls, _MESSAGE_NAME_TO_FIELDS_MAP)
 
 def _msg_inner_to_dict(in_value):
     if type(in_value) in (list, tuple):
@@ -1213,14 +1241,14 @@ def _msg_inner_from_dict(in_value, current_field):
     return in_value
 
 class Message:
-    _minipb_fields_map = None # collections.OrderedDict
-    _minipb_kv_schema  = None # tuple
-    _minipb_wire       = None # Wire
+    __minipb_name_to_fields_map__   = None # collections.OrderedDict
+    __minipb_number_to_fields_map__ = None # dict
+    __minipb_kv_schema__            = None # tuple
+    __minipb_wire__                 = None # Wire
 
     def __init__(self, **kwargs):
-        name_to_fields_map = getattr(self, _MESSAGE_FIELDS_MAP)
-        assert name_to_fields_map is not None, "Missing self.__minipb_fields_map__, forget to decorate Message with @process_message_fields?"
-
+        name_to_fields_map = getattr(self, _MESSAGE_NAME_TO_FIELDS_MAP)
+        assert name_to_fields_map is not None, "Missing self.{}, forget to decorate Message with @process_message_fields?".format(_MESSAGE_NAME_TO_FIELDS_MAP)
         for current_attr, current_field in name_to_fields_map.items():
             value = kwargs.get(current_attr, None)
             if current_field.repeated or current_field.repeated_packed:
@@ -1232,8 +1260,7 @@ class Message:
         if other.__class__ is not self.__class__:
             raise NotImplementedError
 
-        name_to_fields_map = getattr(self, _MESSAGE_FIELDS_MAP)
-        for current_attr in name_to_fields_map.keys():
+        for current_attr in getattr(self, _MESSAGE_NAME_TO_FIELDS_MAP).keys():
             if getattr(self, current_attr) != getattr(other, current_attr):
                 return False
 
@@ -1241,7 +1268,7 @@ class Message:
 
     def to_dict(self, dict_factory=collections.OrderedDict):
         output_map = dict_factory()
-        for attr_name in getattr(self, _MESSAGE_FIELDS_MAP).keys():
+        for attr_name in getattr(self, _MESSAGE_NAME_TO_FIELDS_MAP).keys():
             # Get the value on this instance
             in_value = getattr(self, attr_name)
             out_value = _msg_inner_to_dict(in_value)
@@ -1251,10 +1278,10 @@ class Message:
     def encode(self):
         output_map = self.to_dict()
         return getattr(self, _MESSAGE_WIRE).encode(output_map)
-
+    
     @classmethod
     def from_dict(cls, in_dict):
-        name_to_fields_map = getattr(cls, _MESSAGE_FIELDS_MAP)
+        name_to_fields_map = getattr(cls, _MESSAGE_NAME_TO_FIELDS_MAP)
 
         out_instance = cls()
         for attr_name, current_field in name_to_fields_map.items():

--- a/test.py
+++ b/test.py
@@ -541,7 +541,7 @@ class TestMiniPB(unittest.TestCase):
             test_num = minipb.Field(3, minipb.TYPE_UINT)
             test_str = minipb.Field(4, minipb.TYPE_STRING)
 
-        name_to_fields_map = getattr(TestMessage, minipb._MESSAGE_FIELDS_MAP)
+        name_to_fields_map = getattr(TestMessage, minipb._MESSAGE_NAME_TO_FIELDS_MAP)
         self.assertEqual(name_to_fields_map['test_num'].type, minipb.TYPE_UINT)
 
         expected_field_names = ('zbase_str', 'zbase_num', 'test_num', 'test_str')

--- a/test.py
+++ b/test.py
@@ -400,48 +400,6 @@ class TestMiniPB(unittest.TestCase):
         self.assertIn('more fields after it', details.exception.args[0])
 
 
-    def test_msg_fields_to_kvfmt_complex(self):
-        @minipb.process_message_fields
-        class TestMessage(minipb.Message):
-            @minipb.process_message_fields
-            class NestedMessage(minipb.Message):
-                str2 = minipb.Field(1, minipb.TYPE_STRING)
-                num2 = minipb.Field(2, minipb.TYPE_UINT)
-
-            number = minipb.Field(1, minipb.TYPE_UINT)
-            string = minipb.Field(2, minipb.TYPE_STRING)
-            nested = minipb.Field(3, NestedMessage)
-
-        schema = (
-            ('number', 'T'),
-            ('string', 'U'),
-            ('nested', (('str2', 'U'),
-                        ('num2', 'T'),)),
-        )
-        schema_from_msg = getattr(TestMessage, minipb._MESSAGE_KV_SCHEMA)
-        self.assertEqual(schema_from_msg, schema)
-
-    def test_msg_fields_to_kvfmt_very_complex(self):
-        @minipb.process_message_fields
-        class TestMessage(minipb.Message):
-            @minipb.process_message_fields
-            class NestedMessage(minipb.Message):
-                str2 = minipb.Field(1, minipb.TYPE_STRING)
-                num2 = minipb.Field(2, minipb.TYPE_UINT)
-
-            number = minipb.Field(1, minipb.TYPE_UINT)
-            string = minipb.Field(2, minipb.TYPE_STRING)
-            nested = minipb.Field(3, NestedMessage, repeated=True)
-
-        schema = (
-            ('number', 'T'),
-            ('string', 'U'),
-            ('nested', '+[', (('str2', 'U'),
-                              ('num2', 'T'),)),
-        )
-        schema_from_msg = getattr(TestMessage, minipb._MESSAGE_KV_SCHEMA)
-        self.assertEqual(schema_from_msg, schema)
-
     def _msg_from_raw_obj_with_nested(self):
         n1 = collections.OrderedDict()
         n1['str2'] = 'string'


### PR DESCRIPTION
Sets up minipb to understand/parse basic proto files (parsing not included nor in-scope)

Summary of changes below -
* Refactor to group related code at the module-level, decode/encode of basic types, decode/encode of the wire format itself
* Refactor of some if/elif blocks to switch-style dict statements
* Wire object can now directly understand schemas from Message/Field classes without translating to KV format first
* Wire object's primary purpose now is to understand/apply schemas to decode/encode operations

